### PR TITLE
Use ROOT locale for toLowerCase [1.21.1]

### DIFF
--- a/common/src/main/java/com/witchica/compactstorage/CompactStorage.java
+++ b/common/src/main/java/com/witchica/compactstorage/CompactStorage.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 
 public class CompactStorage {
     public static final String MOD_ID = "compact_storage";
@@ -126,7 +127,7 @@ public class CompactStorage {
 
     static {
         for(int i = 0; i < 16; i++) {
-            String dyeName = DyeColor.byId(i).getName().toLowerCase();
+            String dyeName = DyeColor.byId(i).getName().toLowerCase(Locale.ROOT);
             DyeColor color = DyeColor.byId(i);
             final int id = i;
 

--- a/common/src/main/java/com/witchica/compactstorage/common/client/entity/CompactChestBlockEntityRenderer.java
+++ b/common/src/main/java/com/witchica/compactstorage/common/client/entity/CompactChestBlockEntityRenderer.java
@@ -25,6 +25,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 @Environment(EnvType.CLIENT)
@@ -38,7 +39,7 @@ public class    CompactChestBlockEntityRenderer implements BlockEntityRenderer<C
 
     static {
         for(int i = 0; i < 16; i++) {
-            CHEST_TEXTURES.put(CompactStorage.COMPACT_CHEST_BLOCKS[i].get(), ResourceLocation.fromNamespaceAndPath("compact_storage", String.format("textures/block/chest/%s_chest.png", DyeColor.byId(i).name().toLowerCase())));
+            CHEST_TEXTURES.put(CompactStorage.COMPACT_CHEST_BLOCKS[i].get(), ResourceLocation.fromNamespaceAndPath("compact_storage", String.format("textures/block/chest/%s_chest.png", DyeColor.byId(i).name().toLowerCase(Locale.ROOT))));
         }
 
         for(int i = 0; i < CompactStorageUtil.DRUM_TYPES.length; i++) {

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -30,7 +30,7 @@
 
   "depends": {
     "fabricloader": "${mod_fabric_loader_minimum}",
-    "fabric": "*",
+    "fabric-api": "*",
     "minecraft": "~${minecraft_version}",
     "java": ">=17",
     "architectury": ">=${architectury_version}"


### PR DESCRIPTION
Fixes #188

Also switches to fabric-api mod ID for clarity. 

I also think `"depends": {"minecraft": "~${minecraft_version}"}` where `minecraft_version=1.21` is not good because Minecraft does not follow SemVer. This means it won't stop people from trying to run it on 1.21.2/1.21.3 and above where it crashes. You should instead depend on 1.21, 1.21.1 directly. I'll let you do that though.

Artifacts: https://nightly.link/Poopooracoocoo/compact-storage/actions/runs/12076635022