### PR TITLE
Fix shift-click bypassing existing partial stacks in player inventory

### DIFF
--- a/common/src/main/java/com/witchica/compactstorage/menu/GenericCompactStorageMenu.java
+++ b/common/src/main/java/com/witchica/compactstorage/menu/GenericCompactStorageMenu.java
@@ -82,13 +82,20 @@ public class GenericCompactStorageMenu extends AbstractContainerMenu {
 
         int containerSlotCount = inventoryWidth * inventoryHeight;
 
+        // Balm's QuickMove special-cases a target range literally named "player": it tries the
+        // hotbar sub-range alone first, and only falls back to the inventory sub-range if NOTHING
+        // moved in the hotbar at all. An empty hotbar slot alone counts as "moved", so an item
+        // never gets the chance to top off an existing stack in the main inventory first - it just
+        // goes straight to an empty hotbar slot. Vanilla's real behavior is one merge-then-fill pass
+        // across the whole combined range with no hotbar priority. Registering the container->player
+        // target under any other name sidesteps that special case entirely (the player->container
+        // reverse route is unaffected - the special case only triggers on the TARGET name).
         this.quickMove = QuickMove.create(this::moveItemStackTo)
                 .slotRange(QuickMove.CONTAINER, 0, containerSlotCount)
                 .slotRange(QuickMove.PLAYER, containerSlotCount, containerSlotCount + 36)
-                .slotRange("inventory", containerSlotCount, containerSlotCount + 27)
-                .slotRange("hotbar", containerSlotCount + 27, containerSlotCount + 36)
+                .slotRange("playerCombined", containerSlotCount, containerSlotCount + 36)
                 .disableDefaultRoutes()
-                .route(QuickMove.CONTAINER, QuickMove.PLAYER)
+                .route(QuickMove.CONTAINER, "playerCombined")
                 .route(QuickMove.PLAYER, QuickMove.CONTAINER).build();
     }
 


### PR DESCRIPTION
Balm's QuickMove.Routing treats a range named "player" specially: it tries the "hotbar" sub-range first, and only falls back to "inventory" if hotbar moved literally nothing. Problem is, an empty hotbar slot counts as "moved" too, so shift-clicking an item out of storage skips any partial stack sitting in your inventory and just dumps it into an empty hotbar slot instead.

Fix is one line: rename the container - player destination range to something other than "player" so it stops matching Balm's special case. Player - container is untouched, this only affects the shift-click-out direction.