### PR TITLE
Fix silent item loss past 255/256 slots in oversized storages

### DIFF
--- a/common/src/main/java/com/witchica/compactstorage/block/entity/base/BaseCompactStorageBlockEntity.java
+++ b/common/src/main/java/com/witchica/compactstorage/block/entity/base/BaseCompactStorageBlockEntity.java
@@ -9,6 +9,8 @@ import com.witchica.compactstorage.menu.CompactStorageMenuData;
 import com.witchica.compactstorage.menu.GenericCompactStorageMenu;
 import com.witchica.compactstorage.api.inventory.RetainingContainer;
 import com.witchica.compactstorage.components.ModComponents;
+import com.witchica.compactstorage.inventory.IndexedItemStack;
+import com.witchica.compactstorage.inventory.IndexedItemStackHelper;
 import com.witchica.compactstorage.util.CompactStorageContainerOpenerCounter;
 import net.blay09.mods.balm.world.BalmContainerProvider;
 import net.blay09.mods.balm.world.BalmMenuProvider;
@@ -18,6 +20,7 @@ import net.minecraft.core.HolderLookup;
 import net.minecraft.core.NonNullList;
 import net.minecraft.core.component.DataComponentGetter;
 import net.minecraft.core.component.DataComponentMap;
+import net.minecraft.core.component.DataComponents;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.codec.StreamCodec;
@@ -49,6 +52,15 @@ import org.jspecify.annotations.Nullable;
 import java.util.List;
 
 public abstract class BaseCompactStorageBlockEntity extends BaseContainerBlockEntity implements BalmMenuProvider<@NotNull CompactStorageMenuData>, ResizableContainer, RetainingContainer, VoidSlotProvider, UpgradeCheckProvider, BalmContainerProvider {
+    // Bumped when the "Items" NBT format changed from vanilla ContainerHelper (unsigned-byte slot
+    // index, silently drops items past slot 255) to IndexedItemStackHelper (full-int slot index).
+    private static final int DATA_VERSION = 22;
+
+    // Vanilla's own ItemContainerContents (used when this storage is picked up as an item) throws
+    // past this many entries - stay on the vanilla path under it, our own unbounded component past
+    // it (see collectImplicitComponents).
+    private static final int VANILLA_CONTAINER_COMPONENT_LIMIT = 256;
+
     private NonNullList<ItemStack> items;
 
     private int inventoryWidth ;
@@ -129,22 +141,28 @@ public abstract class BaseCompactStorageBlockEntity extends BaseContainerBlockEn
         writer.store("InventoryWidth", Codec.INT, inventoryWidth);
         writer.store("InventoryHeight", Codec.INT, inventoryHeight);
         writer.store("VoidSlotUpgrade", Codec.BOOL, hasVoidSlot());
-        writer.store("Version", Codec.INT,21);
-        ContainerHelper.saveAllItems(writer, items);
+        writer.store("Version", Codec.INT, DATA_VERSION);
+        IndexedItemStackHelper.saveAllItems(writer, items);
     }
 
     @Override
     protected void loadAdditional(ValueInput reader) {
         super.loadAdditional(reader);
 
-        // -1 for anything before 26.1, 21 for 26.1, useful for any data changes
+        // -1 for anything before 26.1, 21 for 26.1
         int version = reader.getIntOr("Version", -1);
 
         this.inventoryWidth = reader.getIntOr("InventoryWidth", getDefaultWidth());
         this.inventoryHeight = reader.getIntOr("InventoryHeight", getDefaultHeight());
         this.hasVoidSlotUpgrade = reader.getBooleanOr("VoidSlotUpgrade", false);
         this.items = NonNullList.withSize(inventoryWidth * inventoryHeight, ItemStack.EMPTY);
-        ContainerHelper.loadAllItems(reader, items);
+
+        if(version >= DATA_VERSION) {
+            IndexedItemStackHelper.loadAllItems(reader, items);
+        } else {
+            // Only ever needed to read old data; new saves always go through IndexedItemStackHelper.
+            ContainerHelper.loadAllItems(reader, items);
+        }
     }
 
     public void resizeInventory() {
@@ -238,12 +256,32 @@ public abstract class BaseCompactStorageBlockEntity extends BaseContainerBlockEn
 
         setHasVoidSlot(dataComponentGetter.getOrDefault(ModComponents.VOID_SLOT.value(), false).booleanValue());
 
+        // Safe to call unconditionally regardless of size: it only reads vanilla
+        // DataComponents.CONTAINER with a safe (empty) default, never builds one.
         super.applyImplicitComponents(dataComponentGetter);
+
+        List<IndexedItemStack> contents = dataComponentGetter.get(ModComponents.UNBOUNDED_CONTAINER_DATA.value());
+        if(contents != null) {
+            IndexedItemStackHelper.copyFromComponentList(contents, getItems());
+        }
     }
 
     @Override
     protected void collectImplicitComponents(DataComponentMap.Builder dataComponentMap) {
-        super.collectImplicitComponents(dataComponentMap);
+        if(getContainerSize() <= VANILLA_CONTAINER_COMPONENT_LIMIT) {
+            // Under vanilla's own ItemContainerContents cap - let the vanilla behaviour (name,
+            // lock, and the vanilla CONTAINER component) run as normal.
+            super.collectImplicitComponents(dataComponentMap);
+        } else {
+            // BaseContainerBlockEntity's super call unconditionally builds a vanilla
+            // ItemContainerContents from getItems(), which throws IllegalArgumentException past
+            // 256 entries - this mod's storages can have thousands. Preserve the custom name (the
+            // only one of the two exposed by a public getter) and skip the lock component - the
+            // placed block's own lock always round-trips separately via saveAdditional/loadAdditional.
+            dataComponentMap.set(DataComponents.CUSTOM_NAME, getCustomName());
+        }
+
+        dataComponentMap.set(ModComponents.UNBOUNDED_CONTAINER_DATA.value(), IndexedItemStackHelper.toComponentList(getItems()));
         dataComponentMap.set(ModComponents.RETAINING_DATA.value(), this.isRetaining());
         dataComponentMap.set(ModComponents.RESIZABLE_INVENTORY_DATA.value(), new ResizableInventoryComponent(this.getWidth(), this.getHeight()));
         dataComponentMap.set(ModComponents.VOID_SLOT.value(), this.hasVoidSlot());

--- a/common/src/main/java/com/witchica/compactstorage/block/entity/base/BaseItemDrumBlockEntity.java
+++ b/common/src/main/java/com/witchica/compactstorage/block/entity/base/BaseItemDrumBlockEntity.java
@@ -9,6 +9,8 @@ import com.witchica.compactstorage.block.base.BaseCompactStorageBlock;
 import com.witchica.compactstorage.inventory.DrumInventory;
 import com.witchica.compactstorage.block.entity.ModBlockEntities;
 import com.witchica.compactstorage.components.ModComponents;
+import com.witchica.compactstorage.inventory.IndexedItemStack;
+import com.witchica.compactstorage.inventory.IndexedItemStackHelper;
 import com.witchica.compactstorage.upgrades.ModUpgrades;
 import net.blay09.mods.balm.world.BalmContainerProvider;
 import net.blay09.mods.balm.world.level.block.entity.BalmBlockEntityUtils;
@@ -35,9 +37,15 @@ import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 import org.jspecify.annotations.Nullable;
 
+import java.util.List;
 import java.util.Optional;
 
 public class BaseItemDrumBlockEntity extends BlockEntity implements RetainingContainer, UpgradeCheckProvider, ResizableItemDrum, BalmContainerProvider {
+    // Bumped when the "Items" NBT format changed from vanilla ContainerHelper (unsigned-byte slot
+    // index, silently drops items past slot 255 - a real risk once a drum gets upgraded past
+    // vanilla's original 256-stack ceiling) to IndexedItemStackHelper (full-int slot index).
+    private static final int DATA_VERSION = 22;
+
     private DrumInventory drumInventory;
     public Optional<ItemStack> clientItem = Optional.empty();
     public int clientStackSize;
@@ -70,7 +78,7 @@ public class BaseItemDrumBlockEntity extends BlockEntity implements RetainingCon
     protected void saveAdditional(ValueOutput output) {
         super.saveAdditional(output);
 
-        ContainerHelper.saveAllItems(output, drumInventory.getItems());
+        IndexedItemStackHelper.saveAllItems(output, drumInventory.getItems());
 
         if(getStoredType() != Items.AIR) {
             output.store("ClientItem", ItemStack.CODEC, new ItemStack(getStoredType(), 1));
@@ -79,18 +87,24 @@ public class BaseItemDrumBlockEntity extends BlockEntity implements RetainingCon
         output.putInt("ItemDrumSize", getSize());
         output.putInt("ClientStackSize", drumInventory.getMaxStackSize());
         output.putInt("ClientStoredItems", getTotalItemCount());
-        output.putInt("Version", 21);
+        output.putInt("Version", DATA_VERSION);
     }
 
     @Override
     protected void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
 
-        // -1 for anything before 26.1, 21 for 26.1, useful for any data changes
+        // -1 for anything before 26.1, 21 for 26.1
         int version = input.getIntOr("Version", -1);
 
         this.drumInventory = new DrumInventory(input.getIntOr("ItemDrumSize", getDefaultSize()), this);
-        ContainerHelper.loadAllItems(input, drumInventory.getItems());
+
+        if(version >= DATA_VERSION) {
+            IndexedItemStackHelper.loadAllItems(input, drumInventory.getItems());
+        } else {
+            // Only ever needed to read old data; new saves always go through IndexedItemStackHelper.
+            ContainerHelper.loadAllItems(input, drumInventory.getItems());
+        }
 
         this.clientItem = input.read("ClientItem", ItemStack.CODEC);
         this.clientStackSize = input.getIntOr("ClientStackSize", 0);
@@ -145,7 +159,9 @@ public class BaseItemDrumBlockEntity extends BlockEntity implements RetainingCon
     protected void collectImplicitComponents(DataComponentMap.Builder components) {
         super.collectImplicitComponents(components);
         components.set(ModComponents.RETAINING_DATA.value(), isRetaining());
-        components.set(DataComponents.CONTAINER, ItemContainerContents.fromItems(getDrumInventory().getItems()));
+        // Not vanilla's DataComponents.CONTAINER/ItemContainerContents: that throws past 256
+        // entries, and drums can hold many times that once upgraded - see IndexedItemStack.
+        components.set(ModComponents.UNBOUNDED_CONTAINER_DATA.value(), IndexedItemStackHelper.toComponentList(getDrumInventory().getItems()));
         components.set(ModComponents.ITEM_DRUM_SIZE.value(), getSize());
     }
 
@@ -154,7 +170,15 @@ public class BaseItemDrumBlockEntity extends BlockEntity implements RetainingCon
         super.applyImplicitComponents(componentGetter);
         setRetaining(componentGetter.getOrDefault(ModComponents.RETAINING_DATA.value(), false));
         setSize(componentGetter.getOrDefault(ModComponents.ITEM_DRUM_SIZE.value(), getDefaultSize()));
-        componentGetter.getOrDefault(DataComponents.CONTAINER, ItemContainerContents.EMPTY).copyInto(getDrumInventory().getItems());
+
+        List<IndexedItemStack> contents = componentGetter.get(ModComponents.UNBOUNDED_CONTAINER_DATA.value());
+        if(contents != null) {
+            IndexedItemStackHelper.copyFromComponentList(contents, getDrumInventory().getItems());
+        } else {
+            // Migration: a drum item created before this fix carried its contents via vanilla
+            // DataComponents.CONTAINER instead - only ever needed for one-time reads of old items.
+            componentGetter.getOrDefault(DataComponents.CONTAINER, ItemContainerContents.EMPTY).copyInto(getDrumInventory().getItems());
+        }
     }
 
     @Override

--- a/common/src/main/java/com/witchica/compactstorage/components/ModComponents.java
+++ b/common/src/main/java/com/witchica/compactstorage/components/ModComponents.java
@@ -1,20 +1,28 @@
 package com.witchica.compactstorage.components;
 
 import com.mojang.serialization.Codec;
+import com.witchica.compactstorage.inventory.IndexedItemStack;
 import net.blay09.mods.balm.core.component.BalmDataComponentTypeRegistrar;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponentType;
+
+import java.util.List;
 
 public class ModComponents {
     public static Holder<DataComponentType<ResizableInventoryComponent>> RESIZABLE_INVENTORY_DATA;
     public static Holder<DataComponentType<Boolean>> RETAINING_DATA;
     public static Holder<DataComponentType<Boolean>> VOID_SLOT;
     public static Holder<DataComponentType<Integer>> ITEM_DRUM_SIZE;
+    // Item-form contents (backpacks, and item-form pick-up for chests/barrels/drums), using a full
+    // int slot index instead of vanilla DataComponents.CONTAINER's hard 256-entry cap - see
+    // IndexedItemStack/IndexedItemStackHelper.
+    public static Holder<DataComponentType<List<IndexedItemStack>>> UNBOUNDED_CONTAINER_DATA;
 
     public static void initialize(BalmDataComponentTypeRegistrar registrar) {
         RESIZABLE_INVENTORY_DATA = registrar.register("resizable_inventory_data", ResizableInventoryComponent.CODEC).asHolder();
         RETAINING_DATA = registrar.register("retaining_data", Codec.BOOL).asHolder();
         VOID_SLOT = registrar.register("void_slot_data", Codec.BOOL).asHolder();
         ITEM_DRUM_SIZE = registrar.register("item_drum_data", Codec.INT).asHolder();
+        UNBOUNDED_CONTAINER_DATA = registrar.register("unbounded_container_data", IndexedItemStack.CODEC.listOf()).asHolder();
     }
 }

--- a/common/src/main/java/com/witchica/compactstorage/inventory/BackpackInventory.java
+++ b/common/src/main/java/com/witchica/compactstorage/inventory/BackpackInventory.java
@@ -19,6 +19,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.ItemContainerContents;
 import org.jspecify.annotations.NonNull;
+import java.util.List;
 import java.util.Optional;
 
 public class BackpackInventory implements Container, ResizableContainer, VoidSlotProvider {
@@ -58,14 +59,24 @@ public class BackpackInventory implements Container, ResizableContainer, VoidSlo
 
         this.items = NonNullList.withSize(getContainerSize(), ItemStack.EMPTY);
 
-        if(stack.has(DataComponents.CONTAINER)) {
+        // Vanilla's DataComponents.CONTAINER/ItemContainerContents throws past 256 entries, which
+        // this mod's backpacks can now exceed - use our own unbounded component instead (see
+        // IndexedItemStack). Still read the vanilla one as a one-time migration for backpacks
+        // saved before this fix; saveBackpackData always writes the new component from here on.
+        if(stack.has(ModComponents.UNBOUNDED_CONTAINER_DATA.value())) {
+            List<IndexedItemStack> contents = stack.get(ModComponents.UNBOUNDED_CONTAINER_DATA.value());
+
+            if(contents != null) {
+                IndexedItemStackHelper.copyFromComponentList(contents, getItems());
+            }
+        } else if(stack.has(DataComponents.CONTAINER)) {
             ItemContainerContents contents = stack.get(DataComponents.CONTAINER);
 
             if(contents != null) {
                 contents.copyInto(getItems());
             }
         }
-        
+
         if(stack.has(ModComponents.VOID_SLOT.value())) {
             this.hasVoidSlot = backpackStack.get(ModComponents.VOID_SLOT.value()).booleanValue();
         }
@@ -97,7 +108,8 @@ public class BackpackInventory implements Container, ResizableContainer, VoidSlo
         if(stackToSave.isPresent()) {
             ItemStack stack = stackToSave.get();
 
-            stack.set(DataComponents.CONTAINER, ItemContainerContents.fromItems(getItems()));
+            stack.remove(DataComponents.CONTAINER);
+            stack.set(ModComponents.UNBOUNDED_CONTAINER_DATA.value(), IndexedItemStackHelper.toComponentList(getItems()));
             stack.set(ModComponents.RESIZABLE_INVENTORY_DATA.value(), new ResizableInventoryComponent(inventoryWidth, inventoryHeight));
             stack.set(ModComponents.VOID_SLOT.value(), this.hasVoidSlot());
         }

--- a/common/src/main/java/com/witchica/compactstorage/inventory/IndexedItemStack.java
+++ b/common/src/main/java/com/witchica/compactstorage/inventory/IndexedItemStack.java
@@ -1,0 +1,16 @@
+package com.witchica.compactstorage.inventory;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Vanilla's ItemStackWithSlot equivalent, but with a plain int slot index instead of an unsigned
+ * byte - see IndexedItemStackHelper for why that matters.
+ */
+public record IndexedItemStack(int slot, ItemStack stack) {
+    public static final Codec<IndexedItemStack> CODEC = RecordCodecBuilder.create(builder -> builder.group(
+            Codec.INT.fieldOf("Slot").forGetter(IndexedItemStack::slot),
+            ItemStack.MAP_CODEC.forGetter(IndexedItemStack::stack)
+    ).apply(builder, IndexedItemStack::new));
+}

--- a/common/src/main/java/com/witchica/compactstorage/inventory/IndexedItemStackHelper.java
+++ b/common/src/main/java/com/witchica/compactstorage/inventory/IndexedItemStackHelper.java
@@ -1,0 +1,60 @@
+package com.witchica.compactstorage.inventory;
+
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Vanilla's ContainerHelper.saveAllItems/loadAllItems (used for chest/barrel/drum NBT) encode each
+ * stack's slot as ExtraCodecs.UNSIGNED_BYTE, and DataComponents.CONTAINER/ItemContainerContents
+ * (used for item-form contents - backpacks, and any storage picked up as an item) hard-caps at 256
+ * entries and throws past it. Both are fine for vanilla's biggest container (a 54-slot double
+ * chest); neither is fine once this mod's storages can run into the thousands of slots. This
+ * mirrors both shapes with IndexedItemStack's full-int slot instead, so nothing wraps around or
+ * gets rejected past 255/256.
+ */
+public class IndexedItemStackHelper {
+    public static void saveAllItems(ValueOutput output, NonNullList<ItemStack> items) {
+        ValueOutput.TypedOutputList<IndexedItemStack> list = output.list("Items", IndexedItemStack.CODEC);
+
+        for (int i = 0; i < items.size(); i++) {
+            ItemStack stack = items.get(i);
+            if (!stack.isEmpty()) {
+                list.add(new IndexedItemStack(i, stack));
+            }
+        }
+    }
+
+    public static void loadAllItems(ValueInput input, NonNullList<ItemStack> items) {
+        for (IndexedItemStack entry : input.listOrEmpty("Items", IndexedItemStack.CODEC)) {
+            if (entry.slot() >= 0 && entry.slot() < items.size()) {
+                items.set(entry.slot(), entry.stack());
+            }
+        }
+    }
+
+    public static List<IndexedItemStack> toComponentList(List<ItemStack> items) {
+        List<IndexedItemStack> result = new ArrayList<>();
+
+        for (int i = 0; i < items.size(); i++) {
+            ItemStack stack = items.get(i);
+            if (!stack.isEmpty()) {
+                result.add(new IndexedItemStack(i, stack));
+            }
+        }
+
+        return result;
+    }
+
+    public static void copyFromComponentList(List<IndexedItemStack> entries, List<ItemStack> items) {
+        for (IndexedItemStack entry : entries) {
+            if (entry.slot() >= 0 && entry.slot() < items.size()) {
+                items.set(entry.slot(), entry.stack());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Vanilla's ContainerHelper (chest/barrel/drum NBT) writes each stack's slot as an unsigned byte, and DataComponents.CONTAINER (item-form contents — backpacks, picked-up drums) hard-caps at 256 entries and throws past it. Fine for vanilla's biggest container, a 54-slot double chest. Not fine once a storage can run into the thousands of slots: saving past the byte ceiling silently drops whatever didn't fit, and picking up a backpack or drum past the component cap crashes instead.

This adds IndexedItemStack/IndexedItemStackHelper, which write the same shape with a plain int slot index, and switches chest/barrel/drum NBT and backpack/drum item-form storage over to it. A data version bump keeps old saves readable through the original vanilla path, existing backpack/drum items get migrated on first load, and everything new goes through the int-safe path from here on.