### PR TITLE
Reach off-screen items on double-click/shift+double-click, make scroll updates network-free

### DIFF
--- a/common/src/main/java/com/witchica/compactstorage/CompactStorage.java
+++ b/common/src/main/java/com/witchica/compactstorage/CompactStorage.java
@@ -13,6 +13,7 @@ import com.witchica.compactstorage.integration.CompactStorageTrinketsSupport;
 import com.witchica.compactstorage.item.ModItems;
 import com.witchica.compactstorage.menu.ModMenuTypes;
 import com.witchica.compactstorage.network.ServerboundBackpackHotkeyPacket;
+import com.witchica.compactstorage.network.ServerboundCollectMatchingPacket;
 import com.witchica.compactstorage.network.ServerboundScrollStoragePacket;
 import com.witchica.compactstorage.stat.ModStatistics;
 import net.blay09.mods.balm.Balm;
@@ -75,6 +76,7 @@ public class CompactStorage {
 
         Balm.networking().registerServerboundPacket(ServerboundBackpackHotkeyPacket.TYPE, ServerboundBackpackHotkeyPacket.class, ServerboundBackpackHotkeyPacket.STREAM_CODEC, ServerboundBackpackHotkeyPacket::handle);
         Balm.networking().registerServerboundPacket(ServerboundScrollStoragePacket.TYPE, ServerboundScrollStoragePacket.class, ServerboundScrollStoragePacket.STREAM_CODEC, ServerboundScrollStoragePacket::handle);
+        Balm.networking().registerServerboundPacket(ServerboundCollectMatchingPacket.TYPE, ServerboundCollectMatchingPacket.class, ServerboundCollectMatchingPacket.STREAM_CODEC, ServerboundCollectMatchingPacket::handle);
 
         trinkets = Balm.getRuntime().<CompactStorageTrinketsSupport>modProxy()
                 .with("trinkets_updated", "com.witchica.compactstorage.integration.TrinketsUpdatedModSupport")

--- a/common/src/main/java/com/witchica/compactstorage/client/screens/GenericCompactStorageMenuScreen.java
+++ b/common/src/main/java/com/witchica/compactstorage/client/screens/GenericCompactStorageMenuScreen.java
@@ -4,8 +4,10 @@ import com.witchica.compactstorage.CompactStorage;
 import com.witchica.compactstorage.data.StorageType;
 import com.witchica.compactstorage.inventory.ScrollingContainerView;
 import com.witchica.compactstorage.menu.GenericCompactStorageMenu;
+import com.witchica.compactstorage.network.ServerboundCollectMatchingPacket;
 import com.witchica.compactstorage.network.ServerboundScrollStoragePacket;
 import net.blay09.mods.balm.Balm;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.client.input.MouseButtonEvent;
@@ -13,6 +15,7 @@ import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.item.ItemStack;
 import org.joml.Vector2i;
 
 public class GenericCompactStorageMenuScreen extends AbstractContainerScreen<GenericCompactStorageMenu> {
@@ -224,6 +227,17 @@ public class GenericCompactStorageMenuScreen extends AbstractContainerScreen<Gen
         return true;
     }
 
+    // Shift+double-click is vanilla's own "move every matching stack" gesture (distinct from plain
+    // double-click's cursor-collect) - it's resolved entirely client-side in
+    // AbstractContainerScreen#mouseReleased by looping this.menu.slots (our fixed viewport list)
+    // for the item type captured from the shift-click on the FIRST of the two clicks. Captured
+    // here the same way (only overwritten while the hovered slot still has an item, so the second
+    // click - which already emptied it via its own shift-click - doesn't clobber the capture with
+    // empty), then swept server-side in mouseReleased once vanilla's own visible-viewport handling
+    // has run.
+    private ItemStack pendingShiftCollectItem = ItemStack.EMPTY;
+    private boolean pendingDoubleClick;
+
     @Override
     public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
         if(event.button() == 0) {
@@ -238,6 +252,12 @@ public class GenericCompactStorageMenuScreen extends AbstractContainerScreen<Gen
                 dragHorizontalScrollbar(event.x());
                 return true;
             }
+
+            if(Minecraft.getInstance().hasShiftDown() && this.hoveredSlot != null && this.hoveredSlot.hasItem()
+                    && this.hoveredSlot.index < menu.storageView.getContainerSize()) {
+                pendingShiftCollectItem = this.hoveredSlot.getItem().copy();
+            }
+            pendingDoubleClick = doubleClick;
         }
 
         return super.mouseClicked(event, doubleClick);
@@ -263,7 +283,14 @@ public class GenericCompactStorageMenuScreen extends AbstractContainerScreen<Gen
         draggingVerticalScrollbar = false;
         draggingHorizontalScrollbar = false;
 
-        return super.mouseReleased(event);
+        boolean handled = super.mouseReleased(event);
+
+        if(event.button() == 0 && pendingDoubleClick && !pendingShiftCollectItem.isEmpty()) {
+            Balm.networking().sendToServer(new ServerboundCollectMatchingPacket(menu.containerId, pendingShiftCollectItem));
+            pendingShiftCollectItem = ItemStack.EMPTY;
+        }
+
+        return handled;
     }
 
     private void extractVoidSlot(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float a) {

--- a/common/src/main/java/com/witchica/compactstorage/menu/GenericCompactStorageMenu.java
+++ b/common/src/main/java/com/witchica/compactstorage/menu/GenericCompactStorageMenu.java
@@ -114,8 +114,22 @@ public class GenericCompactStorageMenu extends AbstractContainerMenu {
         return storageType;
     }
 
+    // broadcastChanges() runs every server tick and diffs every visible Slot against what it last
+    // told the client - since the viewport Slots all share this one storageView, moving its
+    // scroll offset alone (no real data changed) still looks like every visible slot changed, and
+    // gets resent in full. For BlockEntity-backed storages the client already has the storage's
+    // complete, accurate contents via block-entity NBT sync, entirely independent of this Slot
+    // path - so there's nothing to actually send. setRemoteSlot tells broadcastChanges "the client
+    // already has this value" without sending anything, which makes scroll updates free (see
+    // setItem below for the client-side half of this).
     public void setScroll(int x, int y) {
         storageView.setScroll(x, y);
+
+        if(container instanceof BlockEntity) {
+            for(int i = 0; i < storageView.getContainerSize(); i++) {
+                setRemoteSlot(i, this.slots.get(i).getItem());
+            }
+        }
     }
 
     public void setupSlots() {
@@ -159,6 +173,29 @@ public class GenericCompactStorageMenu extends AbstractContainerMenu {
     public void removed(Player player) {
         super.removed(player);
         container.stopOpen(playerInventory.player);
+    }
+
+    /**
+     * Applies a server-pushed slot correction (from the client's normal AbstractContainerMenu
+     * networking). For storage viewport slots backed by a BlockEntity, the client's real container
+     * is already accurate via block-entity NBT sync, entirely independent of this per-slot path -
+     * broadcastChanges() still fires every tick and pushes "corrections" for the whole viewport
+     * whenever the server's own scroll offset changes, purely because its view shifted, not
+     * because any real data did. If the player scrolls again before one of those arrives, applying
+     * it through the CLIENT's now-different offset writes that item into the wrong real slot -
+     * duplicating/ghosting it. Since the client doesn't need this path for correctness here, feed
+     * the correction back its own already-correct value instead of dropping it outright, so the
+     * state-id reconciliation above still runs normally and the server never has a reason to
+     * suspect desync.
+     */
+    @Override
+    public void setItem(int slotId, int stateId, ItemStack stack) {
+        if(slotId >= 0 && slotId < storageView.getContainerSize() && container instanceof BlockEntity) {
+            super.setItem(slotId, stateId, this.slots.get(slotId).getItem());
+            return;
+        }
+
+        super.setItem(slotId, stateId, stack);
     }
 
     /**

--- a/common/src/main/java/com/witchica/compactstorage/menu/GenericCompactStorageMenu.java
+++ b/common/src/main/java/com/witchica/compactstorage/menu/GenericCompactStorageMenu.java
@@ -17,6 +17,7 @@ import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
+import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
@@ -158,6 +159,122 @@ public class GenericCompactStorageMenu extends AbstractContainerMenu {
     public void removed(Player player) {
         super.removed(player);
         container.stopOpen(playerInventory.player);
+    }
+
+    /**
+     * Double-click ("collect all") is handled by vanilla's private doClick, which only scans
+     * this.slots - our fixed viewport Slot list - so it can never reach real storage slots
+     * currently scrolled out of view. Let vanilla run its normal collection first (covers the
+     * visible viewport and the whole player inventory correctly), then top off whatever it
+     * couldn't reach from the rest of the real container.
+     */
+    @Override
+    public void clicked(int slotIndex, int buttonNum, ContainerInput containerInput, Player player) {
+        super.clicked(slotIndex, buttonNum, containerInput, player);
+
+        if(containerInput == ContainerInput.PICKUP_ALL) {
+            collectRemainingFromStorage();
+        }
+    }
+
+    private void collectRemainingFromStorage() {
+        ItemStack carried = getCarried();
+        if(carried.isEmpty() || carried.getCount() >= carried.getMaxStackSize()) {
+            return;
+        }
+
+        int size = container.getContainerSize();
+        boolean changed = false;
+
+        for(int i = 0; i < size && carried.getCount() < carried.getMaxStackSize(); i++) {
+            ItemStack stack = container.getItem(i);
+            if(stack.isEmpty() || !ItemStack.isSameItemSameComponents(stack, carried)) {
+                continue;
+            }
+
+            int moved = Math.min(carried.getMaxStackSize() - carried.getCount(), stack.getCount());
+            if(moved <= 0) {
+                continue;
+            }
+
+            stack.shrink(moved);
+            carried.grow(moved);
+            changed = true;
+
+            if(stack.isEmpty()) {
+                container.setItem(i, ItemStack.EMPTY);
+            }
+        }
+
+        if(changed) {
+            container.setChanged();
+        }
+    }
+
+    /**
+     * Shift+double-click is vanilla's own "move every matching stack" gesture, resolved entirely
+     * client-side (AbstractContainerScreen#mouseReleased) by looping this.menu.slots - our fixed
+     * viewport list - so it has the same off-screen blind spot as plain double-click. This sweeps
+     * the real container's full range for the same item type into the player's main inventory and
+     * hotbar, the same destination vanilla's own sweep uses.
+     */
+    public void collectMatchingIntoPlayer(ItemStack itemType) {
+        int size = container.getContainerSize();
+        boolean changed = false;
+
+        for(int i = 0; i < size; i++) {
+            ItemStack stack = container.getItem(i);
+            if(stack.isEmpty() || !ItemStack.isSameItemSameComponents(stack, itemType)) {
+                continue;
+            }
+
+            if(insertIntoPlayer(stack)) {
+                changed = true;
+                if(stack.isEmpty()) {
+                    container.setItem(i, ItemStack.EMPTY);
+                }
+            }
+        }
+
+        if(changed) {
+            container.setChanged();
+            playerInventory.setChanged();
+        }
+    }
+
+    /**
+     * Merges/inserts as much of stack as fits into the player's main inventory and hotbar,
+     * mutating stack's count down as progress is made. Returns whether anything moved.
+     * Inventory.getContainerSize() (43) also covers armor/offhand/body/saddle equipment slots
+     * (indices 36-42) - Inventory.INVENTORY_SIZE (36) is just the main+hotbar range this should
+     * touch.
+     */
+    private boolean insertIntoPlayer(ItemStack stack) {
+        int originalCount = stack.getCount();
+
+        for(int i = 0; i < Inventory.INVENTORY_SIZE && !stack.isEmpty(); i++) {
+            ItemStack existing = playerInventory.getItem(i);
+            if(!existing.isEmpty() && ItemStack.isSameItemSameComponents(existing, stack)) {
+                int room = playerInventory.getMaxStackSize(existing) - existing.getCount();
+                if(room > 0) {
+                    int moved = Math.min(room, stack.getCount());
+                    existing.grow(moved);
+                    stack.shrink(moved);
+                }
+            }
+        }
+
+        for(int i = 0; i < Inventory.INVENTORY_SIZE && !stack.isEmpty(); i++) {
+            if(playerInventory.getItem(i).isEmpty()) {
+                int moved = Math.min(playerInventory.getMaxStackSize(stack), stack.getCount());
+                ItemStack placed = stack.copy();
+                placed.setCount(moved);
+                playerInventory.setItem(i, placed);
+                stack.shrink(moved);
+            }
+        }
+
+        return stack.getCount() != originalCount;
     }
 
     @Override

--- a/common/src/main/java/com/witchica/compactstorage/network/ServerboundCollectMatchingPacket.java
+++ b/common/src/main/java/com/witchica/compactstorage/network/ServerboundCollectMatchingPacket.java
@@ -1,0 +1,38 @@
+package com.witchica.compactstorage.network;
+
+import com.witchica.compactstorage.CompactStorage;
+import com.witchica.compactstorage.menu.GenericCompactStorageMenu;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Shift+double-click is vanilla's own "move every matching stack" gesture but resolves it purely
+ * client-side by looping the fixed viewport Slot list. It never learns about matching stacks
+ * scrolled out of view, since those have no Slot at all. Vanilla's own sweep runs unmodified (it's
+ * exactly correct for the visible portion); this packet runs afterward to also sweep the real
+ * container's off-screen slots for the same item type - a no-op for anything vanilla already
+ * moved, so this doesn't need to know the on-screen/off-screen boundary itself.
+ */
+public record ServerboundCollectMatchingPacket(int containerId, ItemStack itemType) implements CustomPacketPayload {
+    public static final Type<ServerboundCollectMatchingPacket> TYPE = new Type<>(CompactStorage.id("collect_matching"));
+    public static final StreamCodec<RegistryFriendlyByteBuf, ServerboundCollectMatchingPacket> STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.VAR_INT, ServerboundCollectMatchingPacket::containerId,
+            ItemStack.STREAM_CODEC, ServerboundCollectMatchingPacket::itemType,
+            ServerboundCollectMatchingPacket::new
+    );
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+    public static void handle(ServerPlayer serverPlayer, ServerboundCollectMatchingPacket packet) {
+        if(serverPlayer.containerMenu.containerId == packet.containerId() && serverPlayer.containerMenu instanceof GenericCompactStorageMenu menu) {
+            menu.collectMatchingIntoPlayer(packet.itemType());
+        }
+    }
+}


### PR DESCRIPTION
Vanilla's double-click ("collect all") and shift+double-click ("move every matching stack") both scan the fixed viewport Slot list, so neither can reach a matching stack scrolled out of view. Both now sweep the real container's off-screen slots afterward.

setScroll previously sent a real slot-correction packet on every notch/drag-frame. For BlockEntity-backed storages the client already has the storage's full contents via block-entity NBT sync, so setRemoteSlot marks those corrections as already-known instead of sending them - scroll updates become free, with no stale-offset race.